### PR TITLE
fix: fix documentation README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ BayesBlend provides an easy-to-use interface for Bayesian model averaging and Ba
 
 Check out the [documentation](https://ledger-investing-bayesblend.readthedocs-hosted.com/en/latest/) for:
 
-* The [Getting Started](https://ledger-investing-bayesblend.readthedocs-hosted.com/en/latest/user-guide/getting-started.md) guide on using BayesBlend.
-* Our [overview](https://ledger-investing-bayesblend.readthedocs-hosted.com/en/latest/user-guide/blending.md) of Bayesian model averaging, stacking, hierarchical stacking and blending. 
-* How BayesBlend [integrates with Arviz](https://ledger-investing-bayesblend.readthedocs-hosted.com/en/latest/user-guide/arviz.md).
-* How to [contribute](https://ledger-investing-bayesblend.readthedocs-hosted.com/en/latest/developer-guide/contributing.md) to BayesBlend.
+* The [Getting Started](https://ledger-investing-bayesblend.readthedocs-hosted.com/en/latest/user-guide/getting-started/) guide on using BayesBlend.
+* Our [overview](https://ledger-investing-bayesblend.readthedocs-hosted.com/en/latest/user-guide/blending/) of Bayesian model averaging, stacking, hierarchical stacking and blending. 
+* How BayesBlend [integrates with Arviz](https://ledger-investing-bayesblend.readthedocs-hosted.com/en/latest/user-guide/arviz/).
+* How to [contribute](https://ledger-investing-bayesblend.readthedocs-hosted.com/en/latest/developer-guide/contributing/) to BayesBlend.


### PR DESCRIPTION
Accidentally used `.md` file extensions in some links. Doh!