### PR TITLE
ci: add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![tests](https://github.com/LedgerInvesting/bayesblend/actions/workflows/python-app.yml/badge.svg)
+![build](https://github.com/LedgerInvesting/bayesblend/actions/workflows/python-app.yml/badge.svg)
 [![ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
 [![docs](https://readthedocs.org/projects/ledger-investing-bayesblend/badge/?version=latest)](https://ledger-investing-bayesblend.readthedocs-hosted.com/en/latest/?badge=latest)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+![build](https://github.com/LedgerInvesting/bayesblend/actions/workflows/python-app.yml/badge.svg)
+[![ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
+
 # BayesBlend
 
 BayesBlend provides an easy-to-use interface for Bayesian model averaging and Bayesian stacking.


### PR DESCRIPTION
Adds some CI-related badges to `README.md` and to `docs/index.md`. The docs workflow badge isn't being generated, and the `docs` badge on the `README.md` is displaying `unknown`. These are, I believe, both because this isn't a public site yet, and we don't have a public RTD site either. I think they'll be fixed once we release. 