### PR TITLE
docs: clarify model averaging throughout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # BayesBlend
 
-BayesBlend provides an easy-to-use interface for Bayesian model averaging and Bayesian stacking. 
+BayesBlend provides an easy-to-use interface to combine predictions from multiple Bayesian models using techniques including (pseudo) Bayesian model averaging, hierarchical stacking, and more!
 
 Check out the [documentation](https://ledger-investing-bayesblend.readthedocs-hosted.com/en/latest/) for:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 # BayesBlend
 
-BayesBlend provides an easy-to-use interface for Bayesian model averaging and Bayesian stacking.
+BayesBlend provides an easy-to-use interface to combine predictions from multiple Bayesian models using techniques including (pseudo) Bayesian model averaging, hierarchical stacking, and more!
 
 This documentation includes a [User Guide](user-guide/index.md) and a [Developer Guide](developer-guide/index.md).
 If you're new to BayesBlend, check out the [Getting Started](user-guide/getting-started.md) guide.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -5,7 +5,7 @@ the `BayesBlendModel` and `Draws` classes.
 
 --------------------------------------------------
 
-BayesBlend provides an easy-to-use interface for Bayesian model averaging and Bayesian stacking. The core functionality is divided into two classes: 
+BayesBlend provides an easy-to-use interface for combining predictions from multiple Bayesian models using techniques including (pseudo) Bayesian model averaging, stacking, and hierarchical stacking. The core functionality is divided into two classes: 
 
 - `Draws`
 - `BayesBlendModel`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "bayesblend"
 version = "0.0.3"
-description = "Easy to use Bayesian model averaging and Bayesian stacking for all your model blending needs!"
+description = "Easily combine predictions from multiple Bayesian models using techniques including (pseudo) Bayesian model averaging, hierarchical stacking, and more!"
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
 


### PR DESCRIPTION
We used the term "Bayesian model averaging" before, but realize that this could be a bit misleading in that we do stacking and pseudo-BMA. Removing the BMA terminology from docs to not confuse users.