### PR TITLE
fix(io): allow multiple dimension lpd arrays in from_lpd method

### DIFF
--- a/bayesblend/io.py
+++ b/bayesblend/io.py
@@ -67,9 +67,7 @@ class Draws:
         return (
             self.log_lik.shape
             if self.log_lik is not None
-            else self.post_pred.shape
-            if self.post_pred is not None
-            else ()
+            else self.post_pred.shape if self.post_pred is not None else ()
         )
 
     @cached_property
@@ -140,8 +138,8 @@ class Draws:
 
     @classmethod
     def from_lpd(cls, lpd: np.ndarray, post_pred: np.ndarray | None = None) -> Draws:
-        shape = (1, len(lpd)) if post_pred is None else post_pred.shape
-        lpd_full = np.full(shape, lpd.reshape((1, len(lpd))))
+        shape = (1, *lpd.shape) if post_pred is None else post_pred.shape
+        lpd_full = np.full(shape, lpd.reshape((1, *lpd.shape)))
         return cls(log_lik=lpd_full, post_pred=post_pred)
 
     def to_arviz(self, dims: Tuple[int, int, int] | None = None) -> az.InferenceData:

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -1,18 +1,18 @@
 import copy
 import json
 from functools import lru_cache
-import arviz as az
 
+import arviz as az
 import numpy as np
 import pytest
 from cmdstanpy import CmdStanModel
 
 from bayesblend import (
-    SimpleBlend,
     BayesStacking,
     HierarchicalBayesStacking,
     MleStacking,
     PseudoBma,
+    SimpleBlend,
 )
 from bayesblend.io import Draws
 
@@ -509,6 +509,17 @@ def test_models_from_lpd():
     # not the logmeanexp
     lpds = {name: fit.log_lik.mean(axis=0) for name, fit in MODEL_DRAWS.items()}
     post_preds = {name: fit.post_pred for name, fit in MODEL_DRAWS.items()}
+    assert MleStacking.from_lpd(lpds, post_preds)
+
+
+def test_model_from_lpd_3d():
+    model_draws = {
+        "fit1": make_draws(-1, [0.9, 0.1], shape=(100, 10, 10)),
+        "fit2": make_draws(-1.3, [0.8, 0.2], shape=(100, 10, 10)),
+        "fit3": make_draws(-1.7, [0.7, 0.3], shape=(100, 10, 10)),
+    }
+    lpds = {name: fit.log_lik.mean(axis=0) for name, fit in model_draws.items()}
+    post_preds = {name: fit.post_pred for name, fit in model_draws.items()}
     assert MleStacking.from_lpd(lpds, post_preds)
 
 


### PR DESCRIPTION
Previously, the Draws.from_lpd method was reshaping the lpd array by referencing it's length, but this failed when the array had multiple dimensions. This fix reshapes by the lpd shape, allowing multiple dimensions in the lpd array (so long as they match the dimension of the post_pred array)