### PR TITLE
fix: predicting on new discrete covariates levels

### DIFF
--- a/bayesblend/io.py
+++ b/bayesblend/io.py
@@ -67,7 +67,9 @@ class Draws:
         return (
             self.log_lik.shape
             if self.log_lik is not None
-            else self.post_pred.shape if self.post_pred is not None else ()
+            else self.post_pred.shape
+            if self.post_pred is not None
+            else ()
         )
 
     @cached_property

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -297,6 +297,8 @@ def test_make_dummy_vars_new_levels():
     assert dummies["dummy_group99"] == [0, 0, 0, 0, 1, 1]
 
 
+
+
 def test_hier_bayes_stacking_predict_different_covariate_levels_pooling():
     hier_bayes_stacking = hierarchical_bayes_stacking_pooling()
     # covariate name is the same, but there is a new level

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -280,23 +280,22 @@ def test_hier_bayes_stacking_pooling():
     # check shape of model prior parameters
     assert all(model_coefs[par].shape == (1, n_models - 1) for par in prior_pars)
 
+
 def test_make_dummy_vars_new_levels():
     discrete_covariate_info = hierarchical_bayes_stacking_pooling().covariate_info
 
     one_new_level = {"dummy": ["group1"] * 2 + ["group99"] * 2}
-    dummies = _make_dummy_vars(one_new_level, discrete_covariate_info) 
+    dummies = _make_dummy_vars(one_new_level, discrete_covariate_info)
     assert list(dummies.keys()) == ["dummy_group2", "dummy_group99"]
     assert not all(dummies["dummy_group2"])
     assert dummies["dummy_group99"] == [0, 0, 1, 1]
 
     two_new_levels = {"dummy": ["group1"] * 2 + ["group0"] * 2 + ["group99"] * 2}
-    dummies = _make_dummy_vars(two_new_levels, discrete_covariate_info) 
+    dummies = _make_dummy_vars(two_new_levels, discrete_covariate_info)
     assert list(dummies.keys()) == ["dummy_group2", "dummy_group0", "dummy_group99"]
     assert not all(dummies["dummy_group2"])
     assert dummies["dummy_group0"] == [0, 0, 1, 1, 0, 0]
     assert dummies["dummy_group99"] == [0, 0, 0, 0, 1, 1]
-
-
 
 
 def test_hier_bayes_stacking_predict_different_covariate_levels_pooling():
@@ -308,7 +307,9 @@ def test_hier_bayes_stacking_predict_different_covariate_levels_pooling():
 
     one_new_level_prev_index = {"dummy": ["group0"] * 2 + ["group1"] * 2}
     with pytest.warns(UserWarning):
-        hier_bayes_stacking._predict_weights(discrete_covariates=one_new_level_prev_index)
+        hier_bayes_stacking._predict_weights(
+            discrete_covariates=one_new_level_prev_index
+        )
 
     two_new_levels = {"dummy": ["group1"] * 2 + ["group99"] * 2 + ["group98"] * 2}
     with pytest.warns(UserWarning):


### PR DESCRIPTION
This PR ensures that:

1) Discrete covariates in `covariate_info` for the `HierarchicalBayesStacking` model are kept as lists and not sets, to ensure that we can trust that the ordering of the covariates matches the order of appearance in the training data. 
2) Ensures that the dummy variable data frame has new levels appended to the end-columns of the dataframe, so that the ordering is preserved, from oldest to newest covariates.