### PR TITLE
Ensure `BayesBlendModel.predict` is reproducible by default

### DIFF
--- a/bayesblend/models.py
+++ b/bayesblend/models.py
@@ -860,7 +860,7 @@ class HierarchicalBayesStacking(BayesBlendModel):
         return self
 
     def _generate_new_level_coefficient(
-        self, idx: int, rng: np.random.RandomState
+        self, idx: int, rng: np.random.Generator
     ) -> np.ndarray:
         return np.atleast_2d(
             rng.normal(

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -97,10 +97,9 @@ def hierarchical_bayes_stacking_pooling_two_discrete_covariates():
         seed=SEED,
     ).fit()
 
-
 @lru_cache
 def fit_models():
-    mle_stacking = MleStacking(model_draws=MODEL_DRAWS).fit()
+    mle_stacking = MleStacking(model_draws=MODEL_DRAWS, seed=SEED).fit()
     bayes_stacking = BayesStacking(model_draws=MODEL_DRAWS, seed=SEED).fit()
     hier_bayes_stacking = hierarchical_bayes_stacking()
     pseudo_bma = PseudoBma(
@@ -165,6 +164,14 @@ def test_model_blending_valid():
     assert isinstance(hier_bayes_stacking._blend(), Draws)
     assert isinstance(pseudo_bma._blend(), Draws)
     assert isinstance(pseudo_bma_plus._blend(), Draws)
+
+
+def test_model_blending_reproducible():
+    models = fit_models()
+
+    for model in models:
+        assert model.fit().weights == model.fit().weights
+        assert model.predict().lpd.sum() == model.predict().lpd.sum()
 
 
 def test_model_predictions_valid():

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -85,6 +85,7 @@ def hierarchical_bayes_stacking_pooling():
         seed=SEED,
     ).fit()
 
+
 @lru_cache
 def hierarchical_bayes_stacking_pooling_two_discrete_covariates():
     new_covariate = {}
@@ -96,6 +97,7 @@ def hierarchical_bayes_stacking_pooling_two_discrete_covariates():
         partial_pooling=True,
         seed=SEED,
     ).fit()
+
 
 @lru_cache
 def fit_models():
@@ -329,13 +331,21 @@ def test_make_dummy_vars_new_levels():
     assert test_dummies["dummy_group10"] == [0, 0, 0]
     assert test_dummies["dummy_group01"] == [0, 1, 1]
 
+
 def test_make_dummy_vars_new_levels_two_covariates():
-    discrete_covariate_info = hierarchical_bayes_stacking_pooling_two_discrete_covariates().covariate_info
+    discrete_covariate_info = (
+        hierarchical_bayes_stacking_pooling_two_discrete_covariates().covariate_info
+    )
 
     one_new_level = {"dummy": ["group1"] * 2 + ["group99"] * 2}
     one_new_level["dummy2"] = one_new_level["dummy"]
     dummies = _make_dummy_vars(one_new_level, discrete_covariate_info)
-    assert list(dummies.keys()) == ["dummy_group2", "dummy2_group2", "dummy_group99", "dummy2_group99"]
+    assert list(dummies.keys()) == [
+        "dummy_group2",
+        "dummy2_group2",
+        "dummy_group99",
+        "dummy2_group99",
+    ]
     assert not all(dummies["dummy_group2"]) and not all(dummies["dummy2_group2"])
     assert dummies["dummy_group99"] == [0, 0, 1, 1]
     assert dummies["dummy2_group99"] == [0, 0, 1, 1]


### PR DESCRIPTION
BayesBlendModel.predict() wasn't always reproducible without passing a seed. For safety, this PR allows users to just call `predict` and it will always use the class's seed by default. 

To allow this, I've added `seed` as an attribute of the ABC, as even `MleStacking` and `PseudoBMA` without bootstrapping need the seed for `predict`.