### PR TITLE
feature: diagnostic plots

### DIFF
--- a/bayesblend/__init__.py
+++ b/bayesblend/__init__.py
@@ -6,6 +6,7 @@ from .models import (
     PseudoBma,
 )
 from .io import Draws
+from .plot import plot_blends
 
 __version__ = "0.0.8"
 
@@ -16,4 +17,5 @@ __all__ = [
     "BayesStacking",
     "HierarchicalBayesStacking",
     "Draws",
+    "plot_blends",
 ]

--- a/bayesblend/models.py
+++ b/bayesblend/models.py
@@ -78,7 +78,7 @@ class BayesBlendModel(ABC):
     def __init__(
         self,
         model_draws: Dict[str, Draws],
-        seed: int | None  = None,
+        seed: int | None = None,
     ) -> None:
         self.model_draws = model_draws
         self._coefficients: Dict[str, np.ndarray]
@@ -651,7 +651,6 @@ class HierarchicalBayesStacking(BayesBlendModel):
             if unknown_priors:
                 raise ValueError(f"Unrecognized priors {unknown_priors}.")
 
-
     def _prepare_covariates(
         self,
         discrete_covariates: Dict[str, Sequence] | None = None,
@@ -1124,17 +1123,15 @@ def _make_dummy_vars(
 
     if discrete_covariate_info is not None:
         unique_levels_info = {
-            k: set().union(v)
-            for k, v
-            in discrete_covariate_info.items()
+            k: set().union(v) for k, v in discrete_covariate_info.items()
         }
-        unique_levels_data = {
-            k: set().union(v)
-            for k, v
-            in discrete_covariates.items()
+        unique_levels_data = {k: set().union(v) for k, v in discrete_covariates.items()}
+        has_missing_levels = {
+            k: unique_levels_info[k] - unique_levels_data[k] for k in unique_levels_info
         }
-        has_missing_levels = {k: unique_levels_info[k] - unique_levels_data[k] for k in unique_levels_info}
-        has_new_levels = {k: unique_levels_data[k] - unique_levels_info[k] for k in unique_levels_data}
+        has_new_levels = {
+            k: unique_levels_data[k] - unique_levels_info[k] for k in unique_levels_data
+        }
 
         # We create dummy coded columns here and append them to the end of the
         # dataframe so that we later know which columns did not originally
@@ -1158,9 +1155,7 @@ def _make_dummy_vars(
                     new_level_dummys[new_covariate] = dummy_codes
 
             ordered_new_level_dummys = {
-                k: new_level_dummys[k]
-                for k in levels_cache
-                if k in new_level_dummys
+                k: new_level_dummys[k] for k in levels_cache if k in new_level_dummys
             }
 
             new_levels_df = pd.DataFrame(ordered_new_level_dummys)
@@ -1180,9 +1175,11 @@ def _make_dummy_vars(
                 [missing_level_df, pd.DataFrame(discrete_covariates)]
             ).apply(lambda i: pd.Categorical(i, categories=i.unique(), ordered=True))  # type: ignore
 
-            dummy_coded_df = pd.get_dummies(
-                concat_all_covariates, dtype=int
-            ).drop(intercepts, axis=1).iloc[len(missing_level_df) :]
+            dummy_coded_df = (
+                pd.get_dummies(concat_all_covariates, dtype=int)
+                .drop(intercepts, axis=1)
+                .iloc[len(missing_level_df) :]
+            )
 
             clean_dummies = pd.concat(
                 [dummy_coded_df.drop(new_levels_df.columns, axis=1), new_levels_df],
@@ -1191,7 +1188,7 @@ def _make_dummy_vars(
             return clean_dummies.to_dict("list")
 
     covariate_df = pd.DataFrame(discrete_covariates).apply(
-        lambda i: pd.Categorical(i, categories=i.unique(), ordered=True) # type: ignore
+        lambda i: pd.Categorical(i, categories=i.unique(), ordered=True)  # type: ignore
     )
     dummies = pd.get_dummies(covariate_df, dtype=int).drop(intercepts, axis=1)
     return pd.concat([dummies, new_levels_df], axis=1).to_dict("list")

--- a/bayesblend/plot.py
+++ b/bayesblend/plot.py
@@ -1,0 +1,147 @@
+from typing import Dict
+import plotly.graph_objects as go # type: ignore
+from plotly.subplots import make_subplots # type: ignore
+from scipy.stats import gaussian_kde
+import numpy as np
+
+from .models import BayesBlendModel
+from . import Draws
+
+COLORS = [
+    "#264653",
+    "#2a9d8f",
+    "#e9c46a",
+    "#f4a261",
+    "#e76f51",
+]
+
+
+def plot_blends(
+    fits: Dict[str, BayesBlendModel], blends: Dict[str, Draws]
+) -> go.Figure:
+    """Plot the BayesBlend predictive distributions alongside
+    the ELPD values for each candidate model and blend.
+
+    This function takes a dictionary of fitted BayesBlendModel
+    objects, which is used to extract the ELPD values of the
+    candidate models, and a dictionary of Draws objects,
+    which will most likely be the output of `BayesBlendModel.predict`.
+
+    Args:
+        fits: Dictionary of BayesBlendModel instances.
+        blends: Dictionary of Draws instances.
+
+    Returns:
+        An instance of plotly.graph_objects.Figure,
+        which can be used for future customization
+        by the user.
+    """
+    R = len(blends)
+    C = 2
+    rc = [(r, c) for r in range(R) for c in range(C)]
+
+    candidates = list(fits[next(iter(fits))].model_draws.keys())
+    blenders = list(blends.keys())
+
+    if not all(list(f.model_draws.keys()) == candidates for f in fits.values()):
+        raise ValueError("All `fits` objects must contain the same models.")
+
+    if any(f.lpd is None for fit in fits.values() for f in fit.model_draws.values()):
+        raise ValueError("All `fits` must have valid log-likelihood values.")
+
+    if any(blend.lpd is None for blend in blends.values()):
+        raise ValueError("All `blends` must have valid log-likelihood values.")
+
+    elpds = {
+        k: (
+            blend.lpd.sum(), # type: ignore
+            elpd_se(blend.lpd),
+        )
+        for k, blend in blends.items()
+    }
+    elpds = elpds | {
+        k: (
+            f.lpd.sum(), # type: ignore
+            elpd_se(f.lpd),
+        )
+        for k, f in fits[next(iter(fits))].model_draws.items()
+    }
+
+    COLOR_LOOKUP = {
+        k: color
+        for k, color in zip(
+            blenders,
+            COLORS,
+        )
+    }
+
+    subplot_titles = [v for t in blenders for v in [f"{t} blend", f"{t} ELPD"]]
+
+    fig = make_subplots(R, C, shared_xaxes="columns", subplot_titles=subplot_titles)
+    fig.update_layout(template="none")
+
+    for i, (r, c) in enumerate(rc):
+        show_legend = False
+        if c == 0:
+            g, d = density(blends[blenders[r]].post_pred.flatten()) # type: ignore
+            fig.add_trace(
+                go.Scatter(
+                    mode="lines",
+                    x=g,
+                    y=d,
+                    marker_color=COLOR_LOOKUP[blenders[r]],
+                    fill="tozeroy",
+                    showlegend=show_legend,
+                    name=blenders[r],
+                ),
+                row=r + 1,
+                col=c + 1,
+            )
+            if r + 1 == R:
+                fig.update_xaxes(title="y", row=r + 1, col=c + 1)
+            fig.update_yaxes(title="Density", row=r + 1, col=c + 1)
+        else:
+            y_labels = [blenders[r], *candidates]
+            elpd, se = zip(*[v for k, v in elpds.items() if k in y_labels])
+            fig.add_trace(
+                go.Scatter(
+                    x=elpd,
+                    y=y_labels,
+                    mode="markers",
+                    error_x={
+                        "type": "data",
+                        "array": se,
+                        "width": 0,
+                        "color": "gray",
+                        "thickness": 0.75,
+                    },
+                    marker_color=[
+                        COLOR_LOOKUP[blenders[r]],
+                        *["gray"] * len(candidates),
+                    ],
+                    marker_symbol=["circle", *["circle-open"] * len(candidates)],
+                    marker_size=12,
+                    showlegend=show_legend,
+                    name=blenders[r],
+                ),
+                row=r + 1,
+                col=c + 1,
+            )
+            if r + 1 == R:
+                fig.update_xaxes(title="ELPD", row=r + 1, col=c + 1)
+
+    fig.update_xaxes(zeroline=False, col=2)
+    fig.update_xaxes(tickfont_size=15)
+    fig.update_yaxes(tickfont_size=15, col=1)
+    fig.update_yaxes(tickfont_size=12, col=2)
+    return fig
+
+
+def elpd_se(lpd: np.ndarray | None) -> float:
+    return lpd.std() * np.sqrt(len(lpd)) # type: ignore
+
+
+def density(x: np.ndarray, steps: int = 500):
+    limits = min(x), max(x)
+    grid = np.linspace(*limits, steps)
+    return grid, gaussian_kde(x)(grid)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1333,6 +1333,21 @@ docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
 
 [[package]]
+name = "plotly"
+version = "5.21.0"
+description = "An open-source, interactive data visualization library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "plotly-5.21.0-py3-none-any.whl", hash = "sha256:a33f41fd5922e45b2b253f795b200d14452eb625790bb72d0a72cf1328a6abbf"},
+    {file = "plotly-5.21.0.tar.gz", hash = "sha256:69243f8c165d4be26c0df1c6f0b7b258e2dfeefe032763404ad7e7fb7d7c2073"},
+]
+
+[package.dependencies]
+packaging = "*"
+tenacity = ">=6.2.0"
+
+[[package]]
 name = "pluggy"
 version = "1.4.0"
 description = "plugin and hook calling mechanisms for python"
@@ -1966,6 +1981,20 @@ test = ["pandas", "pytest", "pytest-cov"]
 ujson = ["ujson (>=5.5.0)"]
 
 [[package]]
+name = "tenacity"
+version = "8.2.3"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tenacity-8.2.3-py3-none-any.whl", hash = "sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c"},
+    {file = "tenacity-8.2.3.tar.gz", hash = "sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx", "tornado (>=4.5)"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -2147,4 +2176,4 @@ test = ["hypothesis", "packaging", "pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0.0"
-content-hash = "fc646aba375d9d4c5024edf26dfa86b060a3f1fb84b38d97e0cf387212f9914f"
+content-hash = "e3da9ec5f0ca0c222a7d6142c39f56bf3b854f847d13449aa721e70ef5eb49d8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ cmdstanpy = "^1.2.1"
 scipy = "^1.12.0"
 matplotlib = "3.7.2"
 arviz = "^0.18.0"
+plotly = "^5.21.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.1.1"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,2 +1,3 @@
+import pytest
 
 pytest_plugins = ["test.fixtures"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,2 @@
+
+pytest_plugins = ["test.fixtures"]

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -1,0 +1,149 @@
+import pytest
+import json
+import numpy as np
+from cmdstanpy import CmdStanModel
+
+from bayesblend import (
+    BayesStacking,
+    HierarchicalBayesStacking,
+    MleStacking,
+    PseudoBma,
+    Draws,
+)
+
+SEED = 1234
+
+RNG = np.random.default_rng(SEED)
+
+STAN_FILE = "test/stan_files/bernoulli_ppc.stan"
+DATA_FILE = "test/stan_data/bernoulli_data.json"
+
+MODEL = CmdStanModel(stan_file=STAN_FILE)
+
+CFG = {"chains": 4, "parallel_chains": 4}
+
+SEED = 1234
+
+with open(DATA_FILE, "r") as f:
+    BERN_DATA = json.load(f)
+
+
+RNG = np.random.RandomState(SEED)
+
+
+@pytest.fixture
+def fit():
+    return MODEL.sample(data=BERN_DATA, **CFG)
+
+
+@pytest.fixture
+def discrete_covariates():
+    return {
+        "dummy": ["group1"] * (BERN_DATA["N"] // 2) + ["group2"] * (BERN_DATA["N"] // 2)
+    }
+
+
+@pytest.fixture
+def continuous_covariates():
+    return {"metric": RNG.normal(size=BERN_DATA["N"])}
+
+
+@pytest.fixture
+def continuous_covariates_zero():
+    return {"metric_zero": np.zeros(BERN_DATA["N"])}
+
+
+def make_draws(mu, p, n_samples=1000, n_datapoints=10, shape=None):
+    shape = (n_samples, n_datapoints) if shape is None else shape
+    return Draws(
+        log_lik=np.array(
+            [RNG.normal(mu, 0.1, n_samples) for _ in range(n_datapoints)]
+        ).T.reshape(shape),
+        post_pred=np.array(
+            [RNG.choice([0, 1], size=n_samples, p=p) for _ in range(n_datapoints)]
+        ).T.reshape(shape),
+    )
+
+
+@pytest.fixture
+def model_draws():
+    return {
+        "fit1": make_draws(-1, [0.9, 0.1]),
+        "fit2": make_draws(-1.3, [0.8, 0.2]),
+        "fit3": make_draws(-1.7, [0.7, 0.3]),
+    }
+
+
+@pytest.fixture
+def model_draws_3d():
+    return {
+        "fit1": make_draws(-1, [0.9, 0.1], shape=(100, 10, 10)),
+        "fit2": make_draws(-1.3, [0.8, 0.2], shape=(100, 10, 10)),
+        "fit3": make_draws(-1.7, [0.7, 0.3], shape=(100, 10, 10)),
+    }
+
+
+@pytest.fixture
+def model_draws_extreme(model_draws):
+    model_draws["fit1"].log_lik[:, 0] = RNG.normal(-1e5, 0.1, 1000)
+    model_draws["fit2"].log_lik[:, 0] = RNG.normal(-1e5, 0.1, 1000)
+    model_draws["fit3"].log_lik[:, 0] = RNG.normal(-1e5, 0.1, 1000)
+    return model_draws
+
+
+@pytest.fixture
+def hierarchical_bayes_stacking(model_draws, discrete_covariates):
+    return HierarchicalBayesStacking(
+        model_draws=model_draws,
+        discrete_covariates=discrete_covariates,
+        seed=SEED,
+    ).fit()
+
+
+@pytest.fixture
+def hierarchical_bayes_stacking_pooling(model_draws, discrete_covariates):
+    return HierarchicalBayesStacking(
+        model_draws=model_draws,
+        discrete_covariates=discrete_covariates,
+        partial_pooling=True,
+        seed=SEED,
+    ).fit()
+
+
+@pytest.fixture
+def hierarchical_bayes_stacking_pooling_two_discrete_covariates(
+    model_draws, discrete_covariates
+):
+    new_covariate = {}
+    new_covariate["dummy2"] = discrete_covariates["dummy"]
+    discrete_covariates = discrete_covariates | new_covariate
+    return HierarchicalBayesStacking(
+        model_draws=model_draws,
+        discrete_covariates=discrete_covariates,
+        partial_pooling=True,
+        seed=SEED,
+    ).fit()
+
+
+@pytest.fixture
+def fit_models(model_draws, hierarchical_bayes_stacking):
+    mle_stacking = MleStacking(model_draws=model_draws, seed=SEED).fit()
+    bayes_stacking = BayesStacking(model_draws=model_draws, seed=SEED).fit()
+    pseudo_bma = PseudoBma(
+        model_draws=model_draws,
+        bootstrap=False,
+        seed=SEED,
+    ).fit()
+    pseudo_bma_plus = PseudoBma(
+        model_draws=model_draws,
+        n_boots=1000,
+        seed=SEED,
+    ).fit()
+
+    return (
+        mle_stacking,
+        bayes_stacking,
+        hierarchical_bayes_stacking,
+        pseudo_bma,
+        pseudo_bma_plus,
+    )

--- a/test/plot_test.py
+++ b/test/plot_test.py
@@ -1,0 +1,19 @@
+import plotly.graph_objects as go
+
+from bayesblend import plot_blends
+
+
+def test_blended_score_plot(fit_models):
+    model_names = (
+        "pseudo_bma",
+        "pseudo_bma+",
+        "mle_stacking",
+        "bayes_stacking",
+        "hierarchical_bayes_stacking",
+    )
+
+    fit_dict = {k: f for k, f in zip(model_names, fit_models)}
+
+    blend_dict = {k: f.predict() for k, f in zip(model_names, fit_models)}
+
+    assert isinstance(plot_blends(fit_dict, blend_dict), go.Figure)


### PR DESCRIPTION
Addresses #43 

I've additionally fleshed out the tests to use `fixtures` instead. Now, all the model draws, model fits etc., are in `tests/fixtures.py`, so they are more easily accessible for other test files, in this case `test_plots.py`.